### PR TITLE
feat: page 제목 컴포넌트로 구현

### DIFF
--- a/frontend/src/components/common/Title.jsx
+++ b/frontend/src/components/common/Title.jsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+function Title({ children }) {
+  return <PageTitle>{children}</PageTitle>;
+}
+
+const PageTitle = styled.div`
+  color: #000000;
+  font-size: 32px;
+  font-family: 'Pretendard';
+  font-weight: 600;
+  text-align: left;
+  margin-left: 250px;
+  margin-top: 50px;
+`;
+
+export default Title;


### PR DESCRIPTION
## Title
feat: page 제목 컴포넌트로 구현

## Desc
- 저장목록, 폴더, 마이페이지 상단에 있는 페이지 제목을 컴포넌트로 구현
- 위치, 폰트, 크기 등 고정

## Type
- [x] Feat
- [ ] Fix
- [ ] Chore
- [ ] Style

## Screenshots
![image](https://github.com/user-attachments/assets/b4dde5f4-33e7-4e93-b139-9ae2c2c50776)
## Reference

## To-Do
- 페이지 속 제목들 해당 컴포넌트로 바꾸기