### PR TITLE
feat: 상세페이지 저장 부분 구현 / 라우팅

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,19 +1,20 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import { MainPage, LoginPage, SignupPage, SaveListPage, SearchResultsPage } from "./pages";
-import { Header } from "../src/components"
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { MainPage, LoginPage, SignupPage, SaveListPage, SearchResultsPage, DetailPage, InFolderPage } from './pages';
+import { Header } from '../src/components';
 
 function App() {
   return (
-      <Router>
-        <Header />
-        <Routes>
-          <Route path="/" element={<MainPage />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/signup" element={<SignupPage />} />
-          <Route path="/savelist" element={<SaveListPage />} />
-          <Route path="/results" element={<SearchResultsPage />} />
-        </Routes>
-      </Router>
+    <Router>
+      <Header />
+      <Routes>
+        <Route path="/" element={<MainPage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/signup" element={<SignupPage />} />
+        <Route path="/savelist" element={<SaveListPage />} />
+        <Route path="/results" element={<SearchResultsPage />} />
+        <Route path="/detail" element={<DetailPage />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/frontend/src/components/Modal/ModalMemo/ModalMemoDelete.jsx
+++ b/frontend/src/components/Modal/ModalMemo/ModalMemoDelete.jsx
@@ -1,0 +1,86 @@
+import ButtonModal from '../../common/Button/ButtonModal';
+import ButtonBasic from '../../common/Button/ButtonBasic';
+import { IoMdClose } from 'react-icons/io';
+import styled from 'styled-components';
+
+export const ModalMemoDelete = ({ openModal, setOpenModal }) => {
+  return (
+    <Overlay>
+      <EditContainer>
+        <CloseButton>
+          <ButtonBasic
+            type="button"
+            onClick={() => {
+              setOpenModal(false);
+            }}>
+            <IoMdClose />
+          </ButtonBasic>
+          {!openModal ? setOpenModal(true) : null}
+        </CloseButton>
+        <StyledText>기록을 삭제하시겠습니까?</StyledText>
+        <SaveButton>
+          <ButtonModal
+            type="button"
+            onClick={() => {
+              setOpenModal(false);
+            }}>
+            삭제하기
+          </ButtonModal>
+          {!openModal ? setOpenModal(true) : null}
+        </SaveButton>
+      </EditContainer>
+    </Overlay>
+  );
+};
+
+const Overlay = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 9999;
+`;
+
+const EditContainer = styled.div`
+  background-color: #ffffff;
+  width: 500px;
+  height: 170px;
+  border: 1px solid #cccccc;
+  border-radius: 20px;
+  padding: 20px;
+  position: relative;
+  font-weight: 600;
+  box-shadow:
+    0 3px 6px rgba(0, 0, 0, 0.16),
+    0 3px 6px rgba(0, 0, 0, 0.23);
+  position: fixed;
+  z-index: 100;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
+const StyledText = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 500px;
+  font-size: 15px;
+  font-weight: 500px;
+  margin-top: 50px;
+`;
+const CloseButton = styled.div`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+`;
+
+const SaveButton = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 50px;
+`;

--- a/frontend/src/components/Modal/ModalMemo/ModalMemoEdit.jsx
+++ b/frontend/src/components/Modal/ModalMemo/ModalMemoEdit.jsx
@@ -1,0 +1,113 @@
+import ButtonModal from '../../common/Button/ButtonModal';
+import ButtonBasic from '../../common/Button/ButtonBasic';
+import { IoMdClose } from 'react-icons/io';
+import styled from 'styled-components';
+import { useState } from 'react';
+
+export const ModalMemoEdit = ({ openModal, setOpenModal, initialValue }) => {
+  // useState로 기존 메모 값을 관리
+  const [memo, setMemo] = useState(initialValue);
+
+  // 메모 입력 변경 핸들러
+  const handleChange = event => {
+    setMemo(event.target.value);
+  };
+
+  return (
+    <Overlay>
+      <EditContainer>
+        <CloseButton>
+          <ButtonBasic
+            type="button"
+            onClick={() => {
+              setOpenModal(false);
+            }}>
+            <IoMdClose />
+          </ButtonBasic>
+        </CloseButton>
+        <InputField
+          type="text"
+          value={memo} // input 필드의 값에 memo 상태 연결
+          onChange={handleChange} // 값이 변경될 때마다 상태 업데이트
+        />
+        <SaveButton>
+          <ButtonModal
+            type="button"
+            onClick={() => {
+              setOpenModal(false);
+              // 여기에 memo 저장하는 로직 추가 가능
+            }}>
+            확인
+          </ButtonModal>
+        </SaveButton>
+      </EditContainer>
+    </Overlay>
+  );
+};
+
+const Overlay = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 9999;
+`;
+
+const EditContainer = styled.div`
+  background-color: #ffffff;
+  width: 500px;
+  height: auto;
+  border: 1px solid #cccccc;
+  border-radius: 20px;
+  padding: 20px;
+  position: relative;
+  font-weight: 600;
+  box-shadow:
+    0 3px 6px rgba(0, 0, 0, 0.16),
+    0 3px 6px rgba(0, 0, 0, 0.23);
+  position: fixed;
+  z-index: 100;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const CloseButton = styled.div`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+`;
+
+const InputField = styled.textarea`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Pretendard';
+  font-weight: 500;
+  font-size: 15px;
+  width: 450px;
+  height: 100px;
+  text-align: left;
+  padding: 10px;
+  border: 1px solid #ffbf87;
+  border-radius: 15px;
+  margin-top: 10px;
+  resize: none;
+  overflow-y: auto;
+`;
+
+const SaveButton = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 20px;
+`;

--- a/frontend/src/components/Modal/index.js
+++ b/frontend/src/components/Modal/index.js
@@ -1,2 +1,4 @@
 export * from './ModalEdit';
 export * from './ModalMemo/ModalMemo';
+export * from './ModalMemo/ModalMemoDelete';
+export * from './ModalMemo/ModalMemoEdit';

--- a/frontend/src/components/common/Button/ButtonBasic.jsx
+++ b/frontend/src/components/common/Button/ButtonBasic.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-function Button({ disabled, children, onClick }) {
+function ButtonBasic({ disabled, children, onClick }) {
   return (
     <StyledButton disabled={disabled} onClick={onClick}>
       {children}
@@ -28,4 +28,4 @@ const StyledButton = styled.button`
   }
 `;
 
-export default Button;
+export default ButtonBasic;

--- a/frontend/src/components/common/Button/index.js
+++ b/frontend/src/components/common/Button/index.js
@@ -1,1 +1,3 @@
 export * from './ButtonEdit';
+export * from './ButtonBasic';
+export * from './HeartButton/HeartButton';

--- a/frontend/src/components/common/StarNumber.jsx
+++ b/frontend/src/components/common/StarNumber.jsx
@@ -1,0 +1,26 @@
+import { PiStarFill, PiStarLight } from 'react-icons/pi';
+import styled from 'styled-components';
+
+const StarContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+`;
+
+const StarRating = ({ children }) => {
+  const rating = Math.round(children);
+
+  return (
+    <StarContainer>
+      {[...Array(5)].map((_, index) =>
+        index < rating ? (
+          <PiStarFill key={index} size={21} color="#FFBF87" />
+        ) : (
+          <PiStarLight key={index} size={21} color="##FFBF87" />
+        ),
+      )}
+    </StarContainer>
+  );
+};
+
+export default StarRating;

--- a/frontend/src/components/placeCard/PlaceCard.jsx
+++ b/frontend/src/components/placeCard/PlaceCard.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import HeartButton from '../common/Button/HeartButton/HeartButton';
 import * as S from './PlaceCard.style';
 
@@ -15,7 +16,7 @@ const PlaceCard = ({ imageUrl, placeName, location, onSave }) => {
   return (
     <S.PlaceCard>
       {/* 이미지 영역 */}
-      <S.ImageContainer>
+      <S.ImageContainer as={Link} to="/detail">
         {imageUrl ? (
           <S.PlaceImage src={imageUrl} alt={placeName} />
         ) : (
@@ -26,7 +27,9 @@ const PlaceCard = ({ imageUrl, placeName, location, onSave }) => {
       {/* 이미지 아래 영역 */}
       <S.TextFrame>
         <S.NameSave>
-          <S.PlaceName>{placeName}</S.PlaceName>
+          <S.PlaceName as={Link} to="/detail" style={{ textDecoration: 'none' }}>
+            {placeName}
+          </S.PlaceName>
           {/* HeartButton 컴포넌트 */}
           <S.HeartbuttonContainer>
             <HeartButton onClick={onSave} />
@@ -34,7 +37,9 @@ const PlaceCard = ({ imageUrl, placeName, location, onSave }) => {
         </S.NameSave>
       </S.TextFrame>
       {/* 장소 위치 */}
-      <S.PlaceLocation>{location}</S.PlaceLocation>
+      <S.PlaceLocation as={Link} to="/detail" style={{ textDecoration: 'none' }}>
+        {location}
+      </S.PlaceLocation>
     </S.PlaceCard>
   );
 };

--- a/frontend/src/pages/DetailPage/DetailPage.jsx
+++ b/frontend/src/pages/DetailPage/DetailPage.jsx
@@ -1,10 +1,13 @@
 import * as S from './DetailPage.style';
+import { LuPenLine } from 'react-icons/lu';
+import { FaRegTrashAlt } from 'react-icons/fa';
+import { IoStar } from 'react-icons/io5';
+import { FaPen } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
+import StarNumber from '../../components/common/StarNumber';
 import { ModalMemo } from '../../components';
 import HeartButton from '../../components/common/Button/HeartButton/HeartButton';
 import { useState } from 'react';
-import { IoStar } from 'react-icons/io5';
-import { FaPen } from 'react-icons/fa';
 
 /*가상데이터*/
 const PlaceInfo = {
@@ -16,9 +19,16 @@ const PlaceInfo = {
   contact: '010-3927-6159',
   starRating: '4.3',
 };
+const SavedMemo = {
+  comment:
+    '커피가 맛있고,, 조용해서 작업하기 좋았다..다크 초콜릿향,,단 카라멜향.여러 견과향이 나며 오렌지와 귤의 화사한 산미와 단맛과 실키한 🍯 꿀같은 부드러움과 중후한 여운과 클린한 마무리감이 너무나도 좋은 프로토콜의 첫번째 블렌드 슈퍼노멀은 달달한 디저트와 너무 잘 어울리고 집중하고 싶을 때 선택해서 마시기 너무 너무 좋았습니다...🎼🌈☺🥰🙏🌳 만들어주신 멋진 선생님들께 ((감사드립니다))🌼🌿🌷🌳 정말 독서, 작업하기 좋은 카페입니다! 의자랑 테이블 넓직하고 커피 산미도 완전 제 취향이고 무화과고르곤졸라휘낭시에는 특이한 메뉴라 시켜봤는데 꼬릿한 치즈향과 무화과 조합이 아주 좋았습니다! 오래 집중하고 싶을 때 또 방문할 것 같아요!!☕️',
+  myStarRating: 4,
+  date: '2025. 01. 26',
+};
 
-const DetailPage = ({ onSave }) => {
+export const DetailPage = ({ onSave }) => {
   const { imageUrl, placeName, location, time, contact, starRating } = PlaceInfo;
+  const { comment, myStarRating, date } = SavedMemo;
   const [saved, setSaved] = useState(false);
 
   const handleSave = () => {
@@ -60,6 +70,7 @@ const DetailPage = ({ onSave }) => {
         <S.PlaceInfo>영업 시간 : &nbsp; {time}</S.PlaceInfo>
         <S.PlaceInfo>전화 번호 : &nbsp;{contact}</S.PlaceInfo>
       </S.PlaceContainer>
+
       {/* 메모 입력 영역 */}
       <S.MemoContainer>
         <S.MemoTitle>
@@ -80,9 +91,20 @@ const DetailPage = ({ onSave }) => {
           </S.AddButton>
           {openModal ? <ModalMemo openModal={openModal} setOpenModal={setOpenModal} /> : null}
         </S.Memo>
+        <S.Saved>
+          <S.SavedMemo>{comment}</S.SavedMemo>
+          <S.SavedRating>
+            <StarNumber>{myStarRating}</StarNumber>
+            <S.SavedDate>{date}</S.SavedDate>
+          </S.SavedRating>
+          <S.EditButton>
+            <LuPenLine size={20} />
+          </S.EditButton>
+          <S.EditButton>
+            <FaRegTrashAlt size={20} />
+          </S.EditButton>
+        </S.Saved>
       </S.MemoContainer>
     </div>
   );
 };
-
-export default DetailPage;

--- a/frontend/src/pages/DetailPage/DetailPage.jsx
+++ b/frontend/src/pages/DetailPage/DetailPage.jsx
@@ -1,11 +1,10 @@
 import * as S from './DetailPage.style';
 import { LuPenLine } from 'react-icons/lu';
-import { FaRegTrashAlt } from 'react-icons/fa';
+import { FaRegTrashAlt, FaPen } from 'react-icons/fa';
 import { IoStar } from 'react-icons/io5';
-import { FaPen } from 'react-icons/fa';
-import { Link } from 'react-router-dom';
 import StarNumber from '../../components/common/StarNumber';
 import { ModalMemo } from '../../components';
+import { ModalMemoDelete, ModalMemoEdit } from '../../components';
 import HeartButton from '../../components/common/Button/HeartButton/HeartButton';
 import { useState } from 'react';
 
@@ -38,7 +37,10 @@ export const DetailPage = ({ onSave }) => {
     }
   };
 
-  const [openModal, setOpenModal] = useState(false);
+  // 각 모달에 대한 개별 상태
+  const [openModalMemo, setOpenModalMemo] = useState(false);
+  const [openModalEdit, setOpenModalEdit] = useState(false);
+  const [openModalDelete, setOpenModalDelete] = useState(false);
 
   return (
     <div>
@@ -85,11 +87,11 @@ export const DetailPage = ({ onSave }) => {
           <S.AddButton
             type="button"
             onClick={() => {
-              setOpenModal(true);
+              setOpenModalMemo(true);
             }}>
             등록
           </S.AddButton>
-          {openModal ? <ModalMemo openModal={openModal} setOpenModal={setOpenModal} /> : null}
+          {openModalMemo && <ModalMemo openModal={openModalMemo} setOpenModal={setOpenModalMemo} />}
         </S.Memo>
         <S.Saved>
           <S.SavedMemo>{comment}</S.SavedMemo>
@@ -97,12 +99,24 @@ export const DetailPage = ({ onSave }) => {
             <StarNumber>{myStarRating}</StarNumber>
             <S.SavedDate>{date}</S.SavedDate>
           </S.SavedRating>
-          <S.EditButton>
+          <S.EditButton
+            type="button"
+            onClick={() => {
+              setOpenModalEdit(true);
+            }}>
             <LuPenLine size={20} />
           </S.EditButton>
-          <S.EditButton>
+          {openModalEdit && (
+            <ModalMemoEdit openModal={openModalEdit} setOpenModal={setOpenModalEdit} initialValue={comment} />
+          )}
+          <S.EditButton
+            type="button"
+            onClick={() => {
+              setOpenModalDelete(true);
+            }}>
             <FaRegTrashAlt size={20} />
           </S.EditButton>
+          {openModalDelete && <ModalMemoDelete openModal={openModalDelete} setOpenModal={setOpenModalDelete} />}
         </S.Saved>
       </S.MemoContainer>
     </div>

--- a/frontend/src/pages/DetailPage/DetailPage.style.jsx
+++ b/frontend/src/pages/DetailPage/DetailPage.style.jsx
@@ -133,9 +133,10 @@ export const Memo = styled.div`
 `;
 
 //입력창
-export const InputField = styled.input`
+export const InputField = styled.textarea`
   display: flex;
   align-items: center;
+  justify-content: center;
   font-family: 'Pretendard';
   font-weight: 500px;
   font-size: 15px;
@@ -143,9 +144,12 @@ export const InputField = styled.input`
   height: 70px;
   text-align: left;
   margin: 10px 0px 10px 50px;
-  padding: 10px;
+  padding: 20px;
   border: 1px solid #ffbf87;
   border-radius: 15px;
+
+  resize: none;
+  overflow: hidden;
 `;
 
 //등록버튼

--- a/frontend/src/pages/DetailPage/DetailPage.style.jsx
+++ b/frontend/src/pages/DetailPage/DetailPage.style.jsx
@@ -92,7 +92,7 @@ export const PlaceInfo = styled.p`
 export const MemoContainer = styled.div`
   justify-content: center;
   width: 1300px;
-  height: 300px;
+  height: auto;
   margin: 20px auto;
   border: 1px solid #d9d9d9;
 `;
@@ -160,5 +160,55 @@ export const AddButton = styled.button`
 
   &:hover {
     background: var(--button-hover-bg-color, #ffbf87);
+  }
+`;
+
+//저장부분
+export const Saved = styled.div`
+  display: flex;
+  margin-bottom: 30px;
+`;
+
+export const SavedMemo = styled.div`
+  display: flex;
+  align-items: center;
+  font-family: 'Pretendard';
+  font-weight: 500px;
+  font-size: 15px;
+  width: 940px;
+  height: auto;
+  text-align: left;
+  margin: 0px 0px 10px 50px;
+  padding: 10px 20px 10px 20px;
+  border: 1px solid #ffbf87;
+  border-radius: 15px;
+
+  overflow-y: auto;
+  word-wrap: 'break-word';
+`;
+
+export const SavedRating = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  color: #ffbf87;
+  margin-left: 20px;
+  margin-right: 15px;
+`;
+
+export const SavedDate = styled.div`
+  font-size: 15px;
+  margin-top: 5px;
+`;
+
+export const EditButton = styled.div`
+  display: flex;
+  align-items: center;
+  margin-right: 5px;
+  margin-left: 10px;
+
+  &:hover {
+    color: #ffbf87;
   }
 `;

--- a/frontend/src/pages/SaveListPage/SaveListPage.jsx
+++ b/frontend/src/pages/SaveListPage/SaveListPage.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { SaveFolder, ButtonEdit, ModalEdit } from '../../components';
 import * as S from './SaveListPage.style';
 
@@ -46,25 +47,27 @@ function SaveListPage() {
 
   return (
     <div>
-      <S.SaveTitleWrapper>
-        <S.SaveTitle>저장 목록</S.SaveTitle>
-        <ButtonEdit
-          type="button"
-          onClick={() => {
-            setOpenModal(true);
-          }}>
-          편집하기
-        </ButtonEdit>
-        {openModal ? <ModalEdit openModal={openModal} setOpenModal={setOpenModal} /> : null}
-      </S.SaveTitleWrapper>
-      <S.SaveFolders>
-        <S.SaveFolderContainer>
-          {/* TODO: 디스트럭처링 필요 */}
-          {folders.map(({ id, imageUrl, folderName }) => (
-            <SaveFolder key={id} imageUrls={imageUrl} folderName={folderName} />
-          ))}
-        </S.SaveFolderContainer>
-      </S.SaveFolders>
+      <Link to="/folder" style={{ textDecoration: 'none', color: 'inherit' }}>
+        <S.SaveTitleWrapper>
+          <S.SaveTitle>저장 목록</S.SaveTitle>
+          <ButtonEdit
+            type="button"
+            onClick={() => {
+              setOpenModal(true);
+            }}>
+            편집하기
+          </ButtonEdit>
+          {openModal ? <ModalEdit openModal={openModal} setOpenModal={setOpenModal} /> : null}
+        </S.SaveTitleWrapper>
+        <S.SaveFolders>
+          <S.SaveFolderContainer>
+            {/* TODO: 디스트럭처링 필요 */}
+            {folders.map(({ id, imageUrl, folderName }) => (
+              <SaveFolder key={id} imageUrls={imageUrl} folderName={folderName} />
+            ))}
+          </S.SaveFolderContainer>
+        </S.SaveFolders>
+      </Link>
     </div>
   );
 }

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -1,5 +1,6 @@
-export { default as LoginPage } from "./LoginSignup/LoginPage";
-export { default as SignupPage } from "./LoginSignup/SignupPage";
-export { default as MainPage } from "./MainPage/MainPage";
-export { default as SaveListPage } from "./SaveListPage/SaveListPage";
-export { default as SearchResultsPage } from "./SearchResultsPage/SearchResultsPage";
+export { default as LoginPage } from './LoginSignup/LoginPage';
+export { default as SignupPage } from './LoginSignup/SignupPage';
+export { default as MainPage } from './MainPage/MainPage';
+export { default as SaveListPage } from './SaveListPage/SaveListPage';
+export { default as SearchResultsPage } from './SearchResultsPage/SearchResultsPage';
+export { DetailPage } from './DetailPage/DetailPage';


### PR DESCRIPTION
## Title
feat: 상세페이지 저장 부분 구현 / 라우팅

## Desc
- 상세페이지 기록 저장 부분 구현
 > 더보기 창 생성 대신 길이에 맞게 창이 늘어나도록 함 `height: auto`
- 상세페이지 편집, 삭제 모달 창 구현
- placeCard에서 상세페이지로 라우팅
- placeCard에서 하트버튼을 제외한 사진, 장소, 주소 부분 클릭 시에만 라우팅

## Type
- [x] Feat
- [x] Fix
- [x] Chore
- [ ] Style

## Screenshots
![제목 없는 디자인 (3)](https://github.com/user-attachments/assets/6d3d3046-70f1-49cd-a8f3-29eceb0a2cba)

## Reference

## To-Do
- API 연결 코드 구현