### PR TITLE
feat: 내계정 회원정보 페이지 모달 구현

### DIFF
--- a/frontend/src/components/Modal/ModalPW/ModalPW.jsx
+++ b/frontend/src/components/Modal/ModalPW/ModalPW.jsx
@@ -1,0 +1,102 @@
+import * as S from './ModalPW.style';
+import ButtonModal from '../../common/Button/ButtonModal';
+import ButtonBasic from '../../common/Button/ButtonBasic';
+import { IoMdClose, IoMdEye, IoMdEyeOff } from 'react-icons/io';
+import { useState } from 'react';
+
+export const ModalPW = ({ openModal, setOpenModal }) => {
+  const [showPW, setShowPW] = useState({
+    current: false,
+    new: false,
+    confirm: false,
+  });
+
+  const [passwords, setPasswords] = useState({
+    current: '',
+    new: '',
+    confirm: '',
+  });
+
+  //비밀번호 숨기기, 보이기
+  const togglePWVisible = field => {
+    setShowPW(prev => ({
+      ...prev,
+      [field]: !prev[field],
+    }));
+  };
+
+  const [errorMessage, setErrorMessage] = useState('');
+
+  //새 비밀번호 불일치할 경우 + 기존 비밀번호 불일치할 경우우의 경고 메시지
+  const handleSave = () => {
+    if (passwords.current !== '현재 비밀번호') {
+      //TODO: '현재 비밀번호'에 실제 비밀번호 데이터 넣기
+      setErrorMessage('현재 비밀번호가 올바르지 않습니다.');
+    } else if (passwords.new !== passwords.confirm) {
+      setErrorMessage('새 비밀번호가 일치하지 않습니다.');
+    } else {
+      setErrorMessage('');
+      setOpenModal(false);
+      //TODO: 비밀번호 변경되도록 하는 코드 삽입
+    }
+  };
+
+  return (
+    <S.Overlay>
+      <S.EditContainer>
+        <S.CloseButton>
+          <ButtonBasic
+            type="button"
+            onClick={() => {
+              setOpenModal(false);
+            }}>
+            <IoMdClose />
+          </ButtonBasic>
+          {!openModal ? setOpenModal(true) : null}
+        </S.CloseButton>
+
+        <S.Text>현재 비밀번호</S.Text>
+        <S.InputWrapper>
+          <S.InputField
+            type={showPW.current ? 'text' : 'password'}
+            placeholder="현재 비밀번호를 입력해주세요"
+            value={passwords.current}
+            onChange={e => setPasswords({ ...passwords, current: e.target.value })}
+          />
+          <S.Icon onClick={() => togglePWVisible('current')}>{showPW.current ? <IoMdEye /> : <IoMdEyeOff />}</S.Icon>
+        </S.InputWrapper>
+
+        <S.Text>새 비밀번호</S.Text>
+        <S.InputWrapper>
+          <S.InputField
+            type={showPW.new ? 'text' : 'password'}
+            placeholder="새 비밀번호를 입력해주세요"
+            value={passwords.new}
+            onChange={e => setPasswords({ ...passwords, new: e.target.value })}
+          />
+          <S.Icon onClick={() => togglePWVisible('new')}>{showPW.new ? <IoMdEye /> : <IoMdEyeOff />}</S.Icon>
+        </S.InputWrapper>
+
+        <S.Text>새 비밀번호 확인</S.Text>
+        <S.InputWrapper>
+          <S.InputField
+            type={showPW.confirm ? 'text' : 'password'}
+            placeholder="새 비밀번호를 다시 입력해주세요"
+            value={passwords.confirm}
+            onChange={e => setPasswords({ ...passwords, confirm: e.target.value })}
+          />
+          <S.Icon onClick={() => togglePWVisible('confirm')}>{showPW.confirm ? <IoMdEye /> : <IoMdEyeOff />}</S.Icon>
+        </S.InputWrapper>
+
+        {errorMessage && <S.ErrorMessage>{errorMessage}</S.ErrorMessage>}
+
+        <S.SaveButton>
+          <ButtonModal type="button" onClick={handleSave}>
+            확인
+          </ButtonModal>
+          {!openModal ? setOpenModal(true) : null}
+        </S.SaveButton>
+      </S.EditContainer>
+    </S.Overlay>
+  );
+};

--- a/frontend/src/components/Modal/ModalPW/ModalPW.style.jsx
+++ b/frontend/src/components/Modal/ModalPW/ModalPW.style.jsx
@@ -1,0 +1,102 @@
+import styled from 'styled-components';
+
+export const Overlay = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+`;
+
+export const EditContainer = styled.div`
+  background-color: #ffffff;
+  width: 420px;
+  padding: 24px;
+  border: 1px solid #cccccc;
+  border-radius: 15px;
+  box-shadow:
+    0 3px 6px rgba(0, 0, 0, 0.16),
+    0 3px 6px rgba(0, 0, 0, 0.23);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+`;
+
+export const CloseButton = styled.button`
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: none;
+  border: none;
+  font-size: 22px;
+  cursor: pointer;
+  color: #555;
+`;
+
+export const SaveButton = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  margin-top: 20px;
+`;
+
+export const Text = styled.div`
+  width: 100%;
+  text-align: left;
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 6px;
+`;
+
+export const InputField = styled.input`
+  width: 100%;
+  font-family: 'Pretendard';
+  font-size: 14px;
+  padding: 12px 16px;
+  border: 1px solid #e3e3e3;
+  border-radius: 7px;
+  background: #fafafa;
+  outline: none;
+
+  &:focus {
+    border: 1px solid #999999;
+  }
+`;
+
+export const InputWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  position: relative;
+  margin-bottom: 16px;
+`;
+
+export const Icon = styled.button`
+  position: absolute;
+  right: 12px;
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  color: #555;
+`;
+
+export const ErrorMessage = styled.div`
+  width: 100%;
+  font-size: 14px;
+  color: #e74c3c; /* 빨간색 */
+  background-color: #f8d7da; /* 연한 빨간 배경 */
+  border: 1px solid #e74c3c; /* 빨간색 테두리 */
+  border-radius: 5px;
+  padding: 10px;
+  margin-top: 10px;
+  text-align: center;
+  font-weight: 600;
+`;

--- a/frontend/src/components/saveFolder/SaveFolder.jsx
+++ b/frontend/src/components/saveFolder/SaveFolder.jsx
@@ -1,7 +1,5 @@
-// TODO: import React 제거
-// https://so-so.dev/react/import-react-from-react/
-import imageIcon from "../../images/imageicon.png";
-import * as S from "./SaveFolder.style";
+import imageIcon from '../../images/imageicon.png';
+import * as S from './SaveFolder.style';
 
 const SaveFolder = ({ imageUrls, folderName }) => {
   const images = imageUrls.length > 0 ? imageUrls : [imageIcon];
@@ -13,7 +11,7 @@ const SaveFolder = ({ imageUrls, folderName }) => {
           <S.PlaceImage key={index} src={url || imageIcon} />
         ))}
       </S.ImageContainer>
-      <S.FolderName>{folderName || "폴더"}</S.FolderName>
+      <S.FolderName>{folderName || '폴더'}</S.FolderName>
     </S.SaveFolder>
   );
 };

--- a/frontend/src/pages/AccountPage/AccountEditPage.jsx
+++ b/frontend/src/pages/AccountPage/AccountEditPage.jsx
@@ -3,8 +3,12 @@ import Title from '../../components/common/Title';
 import { FaCommentAlt } from 'react-icons/fa';
 import { IoPersonSharp } from 'react-icons/io5';
 import { Link } from 'react-router-dom';
+import { useState } from 'react';
+import { ModalPW } from '../../components/Modal/ModalPW/ModalPW';
 
 export function AccountEditPage() {
+  const [openModalPW, setOpenModalPW] = useState(false);
+
   return (
     <div>
       <Title>내 계정</Title>
@@ -27,12 +31,19 @@ export function AccountEditPage() {
       <S.AccountContainer>
         <S.AccountBox>
           <S.Text>닉네임</S.Text>
-          <S.Nickname />
+          <S.Nickname>{/*TODO:실제 닉네임 데이터 삽입*/}</S.Nickname>
           <S.Text>이메일 주소</S.Text>
-          <S.Email></S.Email>
+          <S.Email>{/*TODO:실제 이메일 데이터 삽입*/}</S.Email>
           <S.Password>
             <S.Text>비밀번호</S.Text>
-            <S.ButtonPW>수정</S.ButtonPW>
+            <S.ButtonPW
+              type="button"
+              onClick={() => {
+                setOpenModalPW(true);
+              }}>
+              수정
+            </S.ButtonPW>
+            {openModalPW && <ModalPW openModal={openModalPW} setOpenModal={setOpenModalPW} />}
           </S.Password>
           <S.ButtonINFO>회원 정보 수정</S.ButtonINFO>
         </S.AccountBox>


### PR DESCRIPTION
## Title
feat: 내계정 회원정보 페이지 모달 구현

## Desc
- 비밀번호 숨기기 보이기 설정
- 기존 비밀번호와 다를 경우 / 새 비밀번호와 확인 비밀번호가 다를 경우 경고 메시지 뜨도록

## Type
- [x] Feat
- [ ] Fix
- [ ] Chore
- [ ] Style

## Screenshots
https://github.com/user-attachments/assets/46926635-df24-4f04-802a-1b37a9c6dd71

## Reference

## To-Do
데이터 삽입해야 하는 곳에 TODO 걸어놨습니다 !!

>ModalPW.jsx
1. 기존 비밀번호와도 일치하고 / 2. 새 비밀번호와 확인 비밀번호도 일치하는 경우 **새 비밀번호로 변경되도록 하는 코드** 넣기 (TODO 자리에 넣어주시면 됩니다!)
![image](https://github.com/user-attachments/assets/6d19ce43-3b8e-430f-a8c9-7d2335eea904)

>AccountEditPage.jsx

![image](https://github.com/user-attachments/assets/934161fb-888c-4df9-9c07-1a2c48890bf0)
