### PR TITLE
feat: 가상데이터 추가 (상세페이지, 저장목록, 기록모아보기 페이지)

### DIFF
--- a/frontend/src/components/Modal/ModalEdit/Edit.jsx
+++ b/frontend/src/components/Modal/ModalEdit/Edit.jsx
@@ -1,62 +1,37 @@
-import { useState, useEffect } from 'react';
-import axios from 'axios';
+import { useState } from 'react';
 import CreateFolder from './CreateFolder';
 import FolderList from './FolderList';
-import { API_URLS, COMMON_API_URL } from '../../../consts';
 
-/* 가상 데이터 
+function Edit() {
+  /* 가상 데이터 */
   const [folders, setFolders] = useState([
     { id: '1', folderName: '혼밥 맛집' },
     { id: '2', folderName: '북카페/작업하기 좋은 카페' },
     { id: '3', folderName: '2025년 1월 전시회' },
     { id: '4', folderName: '망원동 소품샵' },
     { id: '5', folderName: '디저트 맛집' },
-  ]);*/
+  ]);
 
-function Edit() {
-  const [folders, setFolders] = useState([]);
   const [folderName, setFolderName] = useState('');
-
-  useEffect(() => {
-    const fetchFolders = async () => {
-      try {
-        const response = await axios.get(API_URLS.folders);
-        setFolders(response.data);
-      } catch (error) {
-        console.error('폴더 불러오기 에러', error);
-      }
-    };
-    fetchFolders();
-  }, []);
 
   const onChange = e => {
     setFolderName(e.target.value);
   };
 
-  const onCreate = async () => {
+  const onCreate = id => {
     if (!folderName.trim()) return;
-    try {
-      const response = await axios.post(API_URLS.folders, { params: { folderName } });
-      setFolders(prevFolders => [...prevFolders, response.data]);
-      setFolderName('');
-    } catch (error) {
-      console.error('폴더 생성 에러', error);
-    }
+
+    const folder = { id, folderName };
+    setFolders([...folders, folder]);
+    setFolderName('');
   };
 
-  const onToggle = folderId => {
-    setFolders(prevFolders =>
-      prevFolders.map(item => (item.folderId === folderId ? { ...item, active: !item.active } : item)),
-    );
+  const onToggle = id => {
+    setFolders(folders.map(item => (item.id === id ? { ...item, active: !item.active } : item)));
   };
 
-  const onRemove = async folderId => {
-    try {
-      await axios.delete(`${COMMON_API_URL}/folders/${folderId}`);
-      setFolders(prevFolders => prevFolders.filter(item => item.folderId !== folderId));
-    } catch (error) {
-      console.error('폴더 삭제 에러', error);
-    }
+  const onRemove = id => {
+    setFolders(folders.filter(item => item.id !== id));
   };
 
   return (

--- a/frontend/src/pages/AccountPage/AccountPage.jsx
+++ b/frontend/src/pages/AccountPage/AccountPage.jsx
@@ -1,20 +1,16 @@
 import * as S from './AccountPage.style';
-import { useEffect, useState } from 'react';
-import axios from 'axios';
 import Title from '../../components/common/Title';
 import { FaCommentAlt } from 'react-icons/fa';
 import { IoPersonSharp } from 'react-icons/io5';
 import { MemoCard } from '../../components/common/MemoCard/MemoCard';
 import { Link } from 'react-router-dom';
-import { API_URLS } from '../../consts';
-import { Error } from '../../components/common';
 
-/*가상 데이터
+/*가상 데이터*/
 const places = [
   {
     id: 1,
     placeName: '프로토콜 연희점',
-    address: '서울 서대문구 연희로 109 2층',
+    location: '서울 서대문구 연희로 109 2층',
     comment:
       '커피가 맛있고,, 조용해서 작업하기 좋았다..다크 초콜릿향,,단 카라멜향.여러 견과향이 나며 오렌지와 귤의 화사한 산미와 단맛과 실키한 🍯 꿀같은 부드러움과 중후한 여운과 클린한 마무리감이 너무나도 좋은 프로토콜의 첫번째 블렌드 슈퍼노멀은 달달한 디저트와 너무 잘 어울리고 집중하고 싶을 때 선택해서 마시기 너무 너무 좋았다...🎼🌈☺🥰🙏🌳 만들어주신 멋진 선생님들께 ((감사드립니다))🌼🌿🌷🌳 정말 독서, 작업하기 좋은 카페다! 의자랑 테이블 넓직하고 커피 산미도 완전 제 취향이고 무화과고르곤졸라휘낭시에는 특이한 메뉴라 시켜봤는데 꼬릿한 치즈향과 무화과 조합이 아주 좋았다! 오래 집중하고 싶을 때 또 방문할 것 같다!!☕️',
     myStarRating: 4,
@@ -23,57 +19,41 @@ const places = [
   {
     id: 2,
     placeName: '텅',
-    address: '서울 종로구 율곡로 82 701호',
+    location: '서울 종로구 율곡로 82 701호',
     comment: '남산 바라보며 책 읽는 시간 보냈다 😌',
     myStarRating: 5,
     date: '2025.01.24',
   },
   {
     id: 3,
-    placeName: '',
-    address: '',
-    comment: '',
-    myStarRating: '',
-    date: '',
+    placeName: '온센 안국점',
+    location: '서울 종로구 율곡로 57-4 온센 안국점',
+    comment:
+      '텐동에 튀김 양도 은근 많고 바삭바삭하니 맛있었다! 튀긴 돼지고기 올라간 카레도 밥이랑 섞어먹다 보니 순식간에 다 먹었는데, 갠적으로 마제우동은 간이 덜 되어 있는 것 같아서 아쉬웠다…. 그래도 전체적인 가게 내부는 깔끔해서 좋았다!',
+    myStarRating: '4',
+    date: '2025.01.12',
   },
   {
     id: 4,
-    placeName: '',
-    address: '',
-    comment: '',
-    myStarRating: '',
-    date: '',
+    placeName: '오레노라멘 인사점',
+    location: '서울 종로구 율곡로 49-4 1층',
+    comment:
+      '내가 먹어본 라멘집 중에 진짜 탑이다.. 날씨가 엄청 추웠는데 따뜻한 국물 먹으니깐 정말 행복했다. 혼밥해도 눈치 안 보이고 줄 서서 먹을 만한 맛집!👍🏻👍🏻',
+    myStarRating: '5',
+    date: '2025.01.10',
   },
   {
     id: 5,
-    placeName: '',
-    address: '',
-    comment: '',
-    myStarRating: '',
-    date: '',
+    placeName: '고유',
+    location: '서울 서대문구 연희로 90-1 2층 202호',
+    comment:
+      '카페 코지코지하고 너무 귀여웠다🤍 취향 저격🧸💕 드립 커피 두 종류 모두 깔끔하고 좋았다 ~☕️🤎고구마 케이키도 귀여운데 넘 맛있어..🍠🍰',
+    myStarRating: '4',
+    date: '2025.01.04',
   },
-];*/
+];
 
 export function AccountPage() {
-  const [places, setPlaces] = useState([]);
-  const [error, setError] = useState(null);
-
-  const fetchPlaces = async () => {
-    try {
-      const response = await axios.get(API_URLS.comment);
-      setPlaces(response.data);
-    } catch (error) {
-      console.error('에러 발생', error);
-      setError(error);
-    }
-  };
-
-  useEffect(() => {
-    fetchPlaces();
-  }, []);
-
-  if (error) return <Error>데이터를 불러오는 중 에러가 발생했습니다.</Error>;
-
   return (
     <div>
       <Title>내 계정</Title>
@@ -95,14 +75,14 @@ export function AccountPage() {
       </S.TabContainer>
 
       <S.MemoCardContainer>
-        {places.map(({ placeId, commentId, placeName, address, comment, myStarRating, date }) => (
+        {places.map(({ id, placeName, location, comment, myStarRating, date }) => (
           <Link
-            key={`${placeId}-${commentId}`}
+            key={id}
             to={`/detail/${encodeURIComponent(placeName)}`}
             style={{ textDecoration: 'none', color: 'inherit' }}>
             <MemoCard
               placeName={placeName}
-              address={address}
+              location={location}
               comment={comment}
               myStarRating={myStarRating}
               date={date}

--- a/frontend/src/pages/DetailPage/DetailPage.jsx
+++ b/frontend/src/pages/DetailPage/DetailPage.jsx
@@ -3,13 +3,10 @@ import { LuPenLine } from 'react-icons/lu';
 import { FaRegTrashAlt, FaPen } from 'react-icons/fa';
 import { IoStar } from 'react-icons/io5';
 import { ModalMemo, ModalMemoDelete, ModalMemoEdit, StarNumber, HeartButton } from '../../components';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import axios from 'axios';
-import { COMMON_API_URL } from '../../consts';
-import { Error } from '../../components/common';
 
-/*가상데이터
+/*가상데이터*/
 const PlaceInfo = [
   {
     imageUrl:
@@ -29,23 +26,55 @@ const PlaceInfo = [
       'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240618_22%2F17186870982432nacB_JPEG%2FIMG_4279.jpg',
     placeName: '텅',
     address: '서울 종로구 율곡로 82 701호',
-    time: '매일 9:00 ~ 23:00',
+    openTime: '매일 9:00 ~ 23:00',
     contact: '02-766-1933',
     starRating: '4.7',
+    comment: '남산 바라보며 책 읽는 시간 보냈다 😌',
+    myStarRating: 5,
+    date: '2025. 01. 24',
   },
-];*/
+  {
+    imageUrl:
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230217_49%2F1676604522315KXQMN_JPEG%2F%25BF%25C2%25BC%25BE%25C5%25D9%25B5%25BF.jpg',
+    placeName: '온센 안국점',
+    address: '서울 종로구 율곡로 57-4 온센 안국점',
+    openTime: '매일 11:00~20:30 (15:10~17:00 브레이크타임 / 14:30, 19:50 라스트오더)',
+    contact: '02-741-2325',
+    starRating: '4.1',
+    comment:
+      '텐동에 튀김 양도 은근 많고 바삭바삭하니 맛있었다! 튀긴 돼지고기 올라간 카레도 밥이랑 섞어먹다 보니 순식간에 다 먹었는데, 갠적으로 마제우동은 간이 덜 되어 있는 것 같아서 아쉬웠다…. 그래도 전체적인 가게 내부는 깔끔해서 좋았다!',
+    myStarRating: '4',
+    date: '2025.01.12',
+  },
+  {
+    imageUrl:
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240530_30%2F1717032756468w7aI1_JPEG%2F%25BF%25C0%25B7%25B9%25B3%25EB%25B6%25F3%25B8%25E0%25C0%25CC%25B9%25CC%25C1%25F6%25BB%25E7%25C1%25F8.jpg',
+    placeName: '오레노라멘 인사점',
+    address: '서울 종로구 율곡로 82 701호',
+    openTime: '매일 10:30 ~ 20:30',
+    contact: '0507-1341-3539',
+    starRating: '4.8',
+    comment:
+      '내가 먹어본 라멘집 중에 진짜 탑이다.. 날씨가 엄청 추웠는데 따뜻한 국물 먹으니깐 정말 행복했다. 혼밥해도 눈치 안 보이고 줄 서서 먹을 만한 맛집!👍🏻👍🏻',
+    myStarRating: '5',
+    date: '2025.01.10',
+  },
+  {
+    imageUrl:
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240107_57%2F1704620911865zGP3o_JPEG%2FIMG_7566.jpeg',
+    placeName: '고유',
+    address: '서울 서대문구 연희로 90-1 2층 202호',
+    openTime: '매일 9:00 ~ 23:00',
+    contact: '02-766-1933',
+    starRating: '4.7',
+    comment:
+      '카페 코지코지하고 너무 귀여웠다🤍 취향 저격🧸💕 드립 커피 두 종류 모두 깔끔하고 좋았다 ~☕️🤎고구마 케이키도 귀여운데 넘 맛있어..🍠🍰',
+    myStarRating: '4',
+    date: '2025.01.04',
+  },
+];
 
 export const DetailPage = ({ onSave }) => {
-  const { placeName } = useParams();
-  const [placeData, setPlaceData] = useState(null);
-  const [error, setError] = useState(null);
-
-  //입력 데이터 상태 관리
-  const [comment, setComment] = useState('');
-  const [myStarRating, setMyStarRating] = useState(null);
-  const [date, setDate] = useState('');
-
-  //하트버튼 상태
   const [saved, setSaved] = useState(false);
   const handleSave = () => {
     setSaved(!saved);
@@ -53,49 +82,26 @@ export const DetailPage = ({ onSave }) => {
       onSave();
     }
   };
-
-  // 각 모달 상태
+  // 각 모달에 대한 개별 상태
   const [openModalMemo, setOpenModalMemo] = useState(false);
   const [openModalEdit, setOpenModalEdit] = useState(false);
   const [openModalDelete, setOpenModalDelete] = useState(false);
+  const { placeName } = useParams();
+  const placeData = PlaceInfo.find(place => place.placeName === decodeURIComponent(placeName));
 
-  useEffect(() => {
-    const fetchPlaceData = async () => {
-      try {
-        const response = await axios.get(`${COMMON_API_URL}/place/detail/${encodeURIComponent(placeName)}`);
-        setPlaceData(response.data);
-      } catch (error) {
-        console.error('에러 발생', error);
-        setError(error);
-      }
-    };
-
-    fetchPlaceData();
-  }, [placeName]);
-
-  if (error) return <Error>데이터를 불러오는 중 오류가 발생했습니다.</Error>;
   if (!placeData) {
     return <div>해당 장소를 찾을 수 없습니다.</div>;
   }
 
-  const handleCommentChange = e => {
-    setComment(e.target.value);
-  };
-
-  const handleSaveMemo = (selectedRating, selectedDate) => {
-    setMyStarRating(selectedRating);
-    setDate(selectedDate);
-    setOpenModalMemo(false);
-  };
+  const { imageUrl, address, openTime, contact, starRating, comment, myStarRating, date } = placeData;
 
   return (
     <div>
       <S.PlaceContainer>
         {/* 이미지 영역 */}
         <S.PlaceImg>
-          {placeData.imageUrl ? <S.PlaceImage src={placeData.imageUrl} alt={placeName} /> : <S.NoImg>No Image</S.NoImg>}
+          {imageUrl ? <S.PlaceImage src={imageUrl} alt={placeName} /> : <S.NoImg>No Image</S.NoImg>}
         </S.PlaceImg>
-
         {/* 정보 텍스트 */}
         <S.TextFrame>
           <S.PlaceName>{placeName}</S.PlaceName>
@@ -104,21 +110,18 @@ export const DetailPage = ({ onSave }) => {
             <HeartButton onClick={handleSave} />
           </S.HeartbuttonContainer>
         </S.TextFrame>
-
         {/*별점*/}
         <S.Rating>
           <S.Star>
             <IoStar />
           </S.Star>
-          후기 {placeData.starRating}
+          후기 {starRating}
         </S.Rating>
-
         {/* 장소 위치 및 정보 */}
-        <S.PlaceInfo>주소 : &nbsp; {placeData.address}</S.PlaceInfo>
-        <S.PlaceInfo>영업 시간 : &nbsp; {placeData.openTime}</S.PlaceInfo>
-        <S.PlaceInfo>전화 번호 : &nbsp;{placeData.contact}</S.PlaceInfo>
+        <S.PlaceInfo>주소 : &nbsp; {address}</S.PlaceInfo>
+        <S.PlaceInfo>영업 시간 : &nbsp; {openTime}</S.PlaceInfo>
+        <S.PlaceInfo>전화 번호 : &nbsp;{contact}</S.PlaceInfo>
       </S.PlaceContainer>
-
       {/* 메모 입력 영역 */}
       <S.MemoContainer>
         <S.MemoTitle>
@@ -129,12 +132,7 @@ export const DetailPage = ({ onSave }) => {
           <S.Text>쉬었다 간 흔적을 남겨주세요</S.Text>
         </S.MemoTitle>
         <S.Memo>
-          <S.InputField
-            type="text"
-            placeholder="오늘의 이 장소는 어땠나요?"
-            value={comment}
-            onChange={handleCommentChange}
-          />
+          <S.InputField type="text" placeholder="오늘의 이 장소는 어땠나요?" />
           <S.AddButton
             type="button"
             onClick={() => {
@@ -142,38 +140,33 @@ export const DetailPage = ({ onSave }) => {
             }}>
             등록
           </S.AddButton>
-          {openModalMemo && (
-            <ModalMemo openModal={openModalMemo} setOpenModal={setOpenModalMemo} onSaveMemo={handleSaveMemo} />
-          )}
+          {openModalMemo && <ModalMemo openModal={openModalMemo} setOpenModal={setOpenModalMemo} />}
         </S.Memo>
-
-        {comment && (
-          <S.Saved>
-            <S.SavedMemo>{comment}</S.SavedMemo>
-            <S.SavedRating>
-              <StarNumber>{myStarRating}</StarNumber>
-              <S.SavedDate>{date}</S.SavedDate>
-            </S.SavedRating>
-            <S.EditButton
-              type="button"
-              onClick={() => {
-                setOpenModalEdit(true);
-              }}>
-              <LuPenLine size={20} />
-            </S.EditButton>
-            {openModalEdit && (
-              <ModalMemoEdit openModal={openModalEdit} setOpenModal={setOpenModalEdit} initialValue={comment} />
-            )}
-            <S.EditButton
-              type="button"
-              onClick={() => {
-                setOpenModalDelete(true);
-              }}>
-              <FaRegTrashAlt size={20} />
-            </S.EditButton>
-            {openModalDelete && <ModalMemoDelete openModal={openModalDelete} setOpenModal={setOpenModalDelete} />}
-          </S.Saved>
-        )}
+        <S.Saved>
+          <S.SavedMemo>{comment}</S.SavedMemo>
+          <S.SavedRating>
+            <StarNumber>{myStarRating}</StarNumber>
+            <S.SavedDate>{date}</S.SavedDate>
+          </S.SavedRating>
+          <S.EditButton
+            type="button"
+            onClick={() => {
+              setOpenModalEdit(true);
+            }}>
+            <LuPenLine size={20} />
+          </S.EditButton>
+          {openModalEdit && (
+            <ModalMemoEdit openModal={openModalEdit} setOpenModal={setOpenModalEdit} initialValue={comment} />
+          )}
+          <S.EditButton
+            type="button"
+            onClick={() => {
+              setOpenModalDelete(true);
+            }}>
+            <FaRegTrashAlt size={20} />
+          </S.EditButton>
+          {openModalDelete && <ModalMemoDelete openModal={openModalDelete} setOpenModal={setOpenModalDelete} />}
+        </S.Saved>
       </S.MemoContainer>
     </div>
   );

--- a/frontend/src/pages/InFolderPage/InFolderPage.jsx
+++ b/frontend/src/pages/InFolderPage/InFolderPage.jsx
@@ -1,34 +1,90 @@
-import { useState, useEffect } from 'react';
-import axios from 'axios';
 import { IoArrowBackSharp } from 'react-icons/io5';
 import * as S from './InFolderPage.style';
 import { PlaceCard } from '../../components';
 import { useParams } from 'react-router-dom';
-import { COMMON_API_URL } from '../../consts';
 
-/*가상 데이터
+// 임시 데이터
 const folders = [
   {
     folderName: '북카페/ 작업하기 좋은 카페',
     places: [
       {
         placeId: 1,
-        imageUrl: 'https://blog.kakaocdn.net/dn/dizeYM/btrN5vZONwk/0ShfJor6t6KANhKzI3Qr1k/img.jpg',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240618_22%2F17186870982432nacB_JPEG%2FIMG_4279.jpg',
         placeName: '텅',
-        address: '서울 종로구 북촌로 701호',
+        location: '서울 종로구 북촌로 701호',
       },
       {
         placeId: 2,
         placeName: '프로토콜 연희점',
-        address: '서울 서대문구 연희로 10길 2층',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20211117_235%2F1637111766001h166z_JPEG%2F04531D1F-5E55-40C2-B669-919206DBFB60.jpeg',
+        location: '서울 서대문구 연희로 10길 2층',
       },
-      { placeId: 3, placeName: '장소', address: '위치' },
-      { placeId: 4, placeName: '장소', address: '위치' },
-      { placeId: 5, placeName: '장소', address: '위치' },
-      { placeId: 6, placeName: '장소', address: '위치' },
-      { placeId: 7, placeName: '장소', address: '위치' },
-      { placeId: 8, placeName: '장소', address: '위치' },
-      { placeId: 9, placeName: '장소', address: '위치' },
+      {
+        placeId: 3,
+        placeName: '고유',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240107_57%2F1704620911865zGP3o_JPEG%2FIMG_7566.jpeg',
+        location: '서울 서대문구 연희로 90-1 2층',
+      },
+      {
+        placeId: 4,
+        placeName: 'umoae',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220413_85%2F1649833914073QB8vK_JPEG%2F1A997AFC-D7DD-4BB3-9A77-32D0860057B7.jpeg',
+        location: '서울 마포구 양화로6길 99-5 1.5층',
+      },
+      {
+        placeId: 5,
+        placeName: '대충유원지',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220930_256%2F1664516460802rDTJO_JPEG%2F2FB1B20B-1E3E-4AA8-9B1E-830A6E4AE6E1.jpeg',
+        location: '서울 마포구 월드컵북로6길 37',
+      },
+      {
+        placeId: 6,
+        placeName: '브라운하우스 연남',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230223_156%2F1677154916028BoLKg_JPEG%2F01.jpg',
+        location: '서울 마포구 동교로50길 25 2, 3층',
+      },
+      {
+        placeId: 7,
+        placeName: '카페 물루',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20250102_3%2F1735801237712v6ci9_JPEG%2FIMG_3845.jpeg',
+        location: '서울 마포구 성미산로6길 8 1층',
+      },
+      {
+        placeId: 8,
+        placeName: '그리즈',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20250103_114%2F1735909103525a9kDg_JPEG%2FIMG_6715.jpeg',
+        location: '서울 마포구 성미산로17길 46 1층',
+      },
+      {
+        placeId: 9,
+        placeName: '종이숲',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240516_220%2F1715869197921sFsNM_JPEG%2FEBE3407D-1D1E-4D25-9F6E-68E46A895E1B.jpeg',
+        location: '서울 마포구 희우정로 93 1층',
+      },
+      {
+        placeId: 10,
+        placeName: '보리수',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fpup-review-phinf.pstatic.net%2FMjAyNDEyMjdfMjU0%2FMDAxNzM1MjczNDU5ODI3.RbXN-4c-bjA4-wFsjAwuQagv-RtXZNUGcfS3bJQmgWQg.V-opanjMN0gbcep54kRE5tBBsxsa_fPKN-n5L1CUxvEg.JPEG%2F5D28F361-390F-4754-8C6A-EF63F264313D.jpeg%3Ftype%3Dw1500_60_sharpen',
+        location: '서울 마포구 성미산로17길 46 1층',
+      },
+      {
+        placeId: 11,
+        placeName: '나루터',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240425_24%2F17140529075904ry77_JPEG%2FP1122399.jpg',
+        location: '서울 송파구 백제고분로41길 19-1 2층',
+      },
     ],
   },
   {
@@ -39,49 +95,200 @@ const folders = [
         imageUrl:
           'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230217_49%2F1676604522315KXQMN_JPEG%2F%25BF%25C2%25BC%25BE%25C5%25D9%25B5%25BF.jpg',
         placeName: '온센 안국점',
-        address: '서울 종로구 율곡로 57-4 온센 안국점',
+        location: '서울 종로구 율곡로 57-4 온센 안국점',
       },
       {
         placeId: 2,
         imageUrl:
           'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240530_30%2F1717032756468w7aI1_JPEG%2F%25BF%25C0%25B7%25B9%25B3%25EB%25B6%25F3%25B8%25E0%25C0%25CC%25B9%25CC%25C1%25F6%25BB%25E7%25C1%25F8.jpg',
         placeName: '오레노라멘 인사점',
-        address: '서울 종로구 율곡로 49-4 1층',
+        location: '서울 종로구 율곡로 49-4 1층',
       },
-
+      {
+        placeId: 3,
+        placeName: '미분당',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240509_298%2F1715232128868dsEs1_JPEG%2F240110_0072.jpg',
+        location: '서울 서대문구 연세로5길 26-7 1층',
+      },
+      {
+        placeId: 4,
+        placeName: '연어초밥',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230321_174%2F1679348900683W8u6i_JPEG%2FFD415EE4-C367-4624-A372-DA932F0E9579.jpeg',
+        location: '서울 서대문구 이화여대1길 42-1 3층',
+      },
+      {
+        placeId: 5,
+        placeName: '까이식당',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20200227_203%2F1582732114593nBqzH_JPEG%2FvEOael5FGEvHVai4xCFzkl46.jpg',
+        location: '서울 서대문구 이화여대2가길 24 1층',
+      },
+      {
+        placeId: 6,
+        placeName: '소오',
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20241226_232%2F1735178171730NzSq5_JPEG%2FGJF01819.jpg',
+        location: '서울 서대문구 이화여대길 50-10 1층',
+      },
     ],
   },
-];*/
-
+  {
+    folderName: '2025년 1월 전시회',
+    places: [
+      {
+        placeId: 1,
+        imageUrl:
+          'https://search.pstatic.net/common?type=o&size=174x242&quality=85&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20250221_205%2F1740103519675rIpi1_JPEG%2F360_main_thumb_url_1740103519662.jpg',
+        placeName: '한글 일일달력 어울림전',
+        location: '뤄니갤러리',
+      },
+      {
+        placeId: 2,
+        imageUrl:
+          'https://search.pstatic.net/common?type=o&size=174x242&quality=85&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20240912_293%2F1726123461731XYPJT_JPEG%2F360_main_thumb_url_1726123461689.jpg',
+        placeName: '불멸의 화가 반 고흐',
+        location: '예술의 전당 한가람미술관',
+      },
+      {
+        placeId: 3,
+        placeName: 'Labor of Love',
+        imageUrl:
+          'https://search.pstatic.net/common?type=ofullfill&size=138x200&quality=95&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20250131_226%2F1738292985203JSlmo_JPEG%2F360_main_thumb_url_1738292985157.jpg',
+        location: '갤러리밈',
+      },
+      {
+        placeId: 4,
+        placeName: '음하영 개인전',
+        imageUrl:
+          'https://search.pstatic.net/common?type=ofullfill&size=138x200&quality=95&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20250131_174%2F1738289915904xL7G9_PNG%2F360_36406181_main_thumb_url_1738289915860.png',
+        location: '이길이구 갤러리',
+      },
+      {
+        placeId: 5,
+        placeName: '숭고한 시뮬라크라라',
+        imageUrl:
+          'https://search.pstatic.net/common?type=ofullfill&size=138x200&quality=95&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20250124_169%2F1737688048669dz89f_JPEG%2F360_main_thumb_url_1737688048643.jpg',
+        location: '리만머핀',
+      },
+      {
+        placeId: 6,
+        placeName: '권두현 개인전',
+        imageUrl:
+          'https://search.pstatic.net/common?type=ofullfill&size=138x200&quality=95&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20250120_237%2F17373533485079rwJC_JPEG%2F360_main_thumb_url_1737353348487.jpg',
+        location: '매스갤러리 한남',
+      },
+      {
+        placeId: 7,
+        placeName: '생동하는 선',
+        imageUrl:
+          'https://search.pstatic.net/common?type=ofullfill&size=138x200&quality=95&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20250122_209%2F1737512277677KlVlC_PNG%2F360_main_thumb_url_1737512277650.png',
+        location: '무아',
+      },
+      {
+        placeId: 8,
+        placeName: 'HIDDEN LIBRARY 2',
+        imageUrl:
+          'https://search.pstatic.net/common?type=ofullfill&size=138x200&quality=95&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20250120_100%2F17373537302917BqtK_JPEG%2F360_main_thumb_url_1737353730268.jpg',
+        location: '플로어',
+      },
+      {
+        placeId: 9,
+        placeName: '사물들의 힘',
+        imageUrl:
+          'https://search.pstatic.net/common?type=ofullfill&size=138x200&quality=95&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20250114_264%2F1736837488140XWi4A_JPEG%2F360_main_thumb_url_1736837488091.jpg',
+        location: '스페이스 이수',
+      },
+    ],
+  },
+  {
+    folderName: '디저트 맛집',
+    places: [
+      {
+        placeId: 1,
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20250205_77%2F1738710710150sxGs2_JPEG%2FIMG_5896.jpeg',
+        placeName: '바나나하루키',
+        location: '서울 마포구 동교로38길 6 3층',
+      },
+      {
+        placeId: 2,
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240312_44%2F1710250763316DRweN_JPEG%2F325C82C4-6956-4A71-BAAB-61ED67F9AE13.jpeg',
+        placeName: 'bokeh',
+        location: '서울 서대문구 연희로 116 2층',
+      },
+      {
+        placeId: 3,
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20241204_261%2F17332890289799bGsw_JPEG%2F73911D5E-7D0B-4987-B882-6B3012F16836.jpeg',
+        placeName: '해피앤피스커피클럽',
+        location: '서울 서대문구 연희로 134 1층',
+      },
+      {
+        placeId: 4,
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230419_29%2F1681906232406lQa4o_JPEG%2F12345.jpg',
+        placeName: '보통공원',
+        location: '서울 마포구 망원로 79 3층',
+      },
+      {
+        placeId: 5,
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220430_217%2F1651295611452VEvii_JPEG%2FA4EDF253-5ABC-4275-AAE9-1D6EA1ADBC58.jpeg',
+        placeName: '모을',
+        location: '서울 마포구 월드컵로19길 71 3층',
+      },
+    ],
+  },
+  {
+    folderName: '망원동 소품샵',
+    places: [
+      {
+        placeId: 1,
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240212_27%2F1707726814442sYokb_JPEG%2F2024-02-12_17%253B26%253B59.JPG',
+        placeName: '떠블유떠블유',
+        location: '서울 마포구 포은로5길 15 2층',
+      },
+      {
+        placeId: 2,
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220519_153%2F1652919854082GJJHi_JPEG%2FZEROSPACE.jpg',
+        placeName: '제로스페이스 망원',
+        location: '서울 마포구 희우정로16길 32',
+      },
+      {
+        placeId: 3,
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20231124_129%2F1700815642718xKEk1_JPEG%2FKakaoTalk_20231124_174255822_01.jpg',
+        placeName: '테라스웨어',
+        location: '서울 마포구 월드컵로19길 25 1층',
+      },
+      {
+        placeId: 4,
+        imageUrl:
+          'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230407_239%2F1680795370210URGg8_JPEG%2F20230404_151035.jpg',
+        placeName: '두두상점',
+        location: '서울 마포구 포은로 80 1층',
+      },
+    ],
+  },
+];
 function InFolderPage() {
-  const { folderName } = useParams();
-  const [places, setPlaces] = useState(null);
-  const [error, setError] = useState(null);
-
-  useEffect(() => {
-    const fetchPlaces = async () => {
-      try {
-        const response = await axios.get(`${COMMON_API_URL}/folders/${encodeURIComponent(folderName)}`);
-        setPlaces(response.data);
-      } catch (error) {
-        console.error('에러 발생', error);
-        setError(error);
-      }
-    };
-
-    fetchPlaces();
-  }, [folderName]);
-
   const handleSave = () => {
     alert('장소가 저장되었습니다!');
   };
 
-  if (error) {
-    return <div>데이터를 불러오는 중 오류가 발생했습니다.</div>;
-  }
-  if (!places) {
+  const { folderName } = useParams();
+  const currentFolder = folders.find(folder => decodeURIComponent(folder.folderName) === folderName);
+
+  if (!currentFolder) {
     return <div>해당 폴더에 저장된 장소가 없습니다.</div>;
   }
+
+  const { places } = currentFolder;
 
   return (
     <div>
@@ -99,5 +306,4 @@ function InFolderPage() {
     </div>
   );
 }
-
 export default InFolderPage;

--- a/frontend/src/pages/SaveListPage/SaveListPage.jsx
+++ b/frontend/src/pages/SaveListPage/SaveListPage.jsx
@@ -1,50 +1,64 @@
-import { useState, useEffect } from 'react';
-import axios from 'axios';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { SaveFolder, ButtonEdit, ModalEdit } from '../../components';
 import * as S from './SaveListPage.style';
-import { COMMON_API_URL } from '../../consts';
-import { Error } from '../../components/common';
 
-/*가상 데이터
+/*가상 데이터*/
 const folders = [
-  { folderId: 1, imageUrl: [], folderName: '혼밥 맛집' },
+  {
+    folderId: 1,
+    imageUrl: [
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230217_49%2F1676604522315KXQMN_JPEG%2F%25BF%25C2%25BC%25BE%25C5%25D9%25B5%25BF.jpg',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240530_30%2F1717032756468w7aI1_JPEG%2F%25BF%25C0%25B7%25B9%25B3%25EB%25B6%25F3%25B8%25E0%25C0%25CC%25B9%25CC%25C1%25F6%25BB%25E7%25C1%25F8.jpg',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240509_298%2F1715232128868dsEs1_JPEG%2F240110_0072.jpg',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230321_174%2F1679348900683W8u6i_JPEG%2FFD415EE4-C367-4624-A372-DA932F0E9579.jpeg',
+    ],
+    folderName: '혼밥 맛집',
+  },
   {
     folderId: 2,
     imageUrl: [
-      'https://blog.kakaocdn.net/dn/dizeYM/btrN5vZONwk/0ShfJor6t6KANhKzI3Qr1k/img.jpg',
-      'https://storage.heypop.kr/assets/2024/02/26114133/main.1-scaled.jpg',
-      'https://www.visitseoul.net/comm/getImage?srvcId=MEDIA&parentSn=49036&fileTy=MEDIA&fileNo=1',
-      'https://www.visitseoul.net/comm/getImage?srvcId=MEDIA&parentSn=49035&fileTy=MEDIA&fileNo=1',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240618_22%2F17186870982432nacB_JPEG%2FIMG_4279.jpg',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20211117_235%2F1637111766001h166z_JPEG%2F04531D1F-5E55-40C2-B669-919206DBFB60.jpeg',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240107_57%2F1704620911865zGP3o_JPEG%2FIMG_7566.jpeg',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220413_85%2F1649833914073QB8vK_JPEG%2F1A997AFC-D7DD-4BB3-9A77-32D0860057B7.jpeg',
     ],
     folderName: '북카페/ 작업하기 좋은 카페',
   },
-  { folderId: 3, imageUrl: [], folderName: '2025년 1월 전시회' },
-  { folderId: 4, imageUrl: [], folderName: '망원동 소품샵' },
-  { folderId: 5, imageUrl: [], folderName: null },
-  { folderId: 6, imageUrl: [], folderName: null },
-];*/
+  {
+    folderId: 3,
+    imageUrl: [
+      'https://search.pstatic.net/common?type=o&size=174x242&quality=85&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20250221_205%2F1740103519675rIpi1_JPEG%2F360_main_thumb_url_1740103519662.jpg',
+      'https://search.pstatic.net/common?type=o&size=174x242&quality=85&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20240912_293%2F1726123461731XYPJT_JPEG%2F360_main_thumb_url_1726123461689.jpg',
+      'https://search.pstatic.net/common?type=ofullfill&size=138x200&quality=95&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20250131_226%2F1738292985203JSlmo_JPEG%2F360_main_thumb_url_1738292985157.jpg',
+      'https://search.pstatic.net/common?type=ofullfill&size=138x200&quality=95&direct=true&src=https%3A%2F%2Fcsearch-phinf.pstatic.net%2F20250131_174%2F1738289915904xL7G9_PNG%2F360_36406181_main_thumb_url_1738289915860.png',
+    ],
+    folderName: '2025년 1월 전시회',
+  },
+  {
+    folderId: 4,
+    imageUrl: [
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240212_27%2F1707726814442sYokb_JPEG%2F2024-02-12_17%253B26%253B59.JPG',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220519_153%2F1652919854082GJJHi_JPEG%2FZEROSPACE.jpg',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20231124_129%2F1700815642718xKEk1_JPEG%2FKakaoTalk_20231124_174255822_01.jpg',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230407_239%2F1680795370210URGg8_JPEG%2F20230404_151035.jpg',
+    ],
+    folderName: '망원동 소품샵',
+  },
+  {
+    folderId: 5,
+    imageUrl: [
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20250205_77%2F1738710710150sxGs2_JPEG%2FIMG_5896.jpeg',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240312_44%2F1710250763316DRweN_JPEG%2F325C82C4-6956-4A71-BAAB-61ED67F9AE13.jpeg',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20241204_261%2F17332890289799bGsw_JPEG%2F73911D5E-7D0B-4987-B882-6B3012F16836.jpeg',
+      'https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230419_29%2F1681906232406lQa4o_JPEG%2F12345.jpg',
+    ],
+    folderName: '디저트 맛집',
+  },
+];
 
 function SaveListPage() {
   const [openModal, setOpenModal] = useState(false);
-  const [folders, setFolders] = useState([]);
-  const [error, setError] = useState(null);
-
-  const fetchFolders = async () => {
-    try {
-      const response = await axios.get(`${COMMON_API_URL}/folders`);
-      setFolders(response.data);
-    } catch (error) {
-      console.error('데이터 가져오기 에러', error);
-      setError(error);
-    }
-  };
-
-  useEffect(() => {
-    fetchFolders();
-  }, []);
-
-  if (error) return <Error>데이터를 불러오는 중 오류가 발생했습니다.</Error>;
 
   return (
     <div>
@@ -60,9 +74,9 @@ function SaveListPage() {
         <S.SaveFolderContainer>
           {folders
             .filter(folder => folder.folderName)
-            .map(({ folderId, imageUrl, folderName }) => (
+            .map(({ id, imageUrl, folderName }) => (
               <Link
-                key={folderId}
+                key={id}
                 to={`/folder/${encodeURIComponent(folderName)}`}
                 style={{ textDecoration: 'none', color: 'inherit' }}>
                 <SaveFolder imageUrls={imageUrl} folderName={folderName} />


### PR DESCRIPTION
## Title
feat: 가상데이터 추가 (상세페이지, 저장목록, 기록모아보기 페이지)

## Desc
- 가상데이터 추가 (상세페이지, 저장목록, 기록모아보기 페이지)

## Type
- [x] Feat
- [ ] Fix
- [ ] Chore
- [ ] Style

## Screenshots
![image](https://github.com/user-attachments/assets/49f2b9fd-2580-4618-a98a-89b7119636ed)
> 우선 기록 모아보기에 있는 장소만 상세페이지 데이터 작성
![image](https://github.com/user-attachments/assets/916d2d83-f562-4976-9c92-ee45736581e9)

![image](https://github.com/user-attachments/assets/dba6d706-11cd-4356-b53e-a76a5ac2fc31)

![image](https://github.com/user-attachments/assets/f9082a47-d3d5-41e5-9140-996aabab583b)



## Reference

## To-Do
- 저장목록 내의 장소카드 하트버트 on으로 고정